### PR TITLE
Work around likely Textual bug with `OptionList`

### DIFF
--- a/src/peplum/app/screens/main.py
+++ b/src/peplum/app/screens/main.py
@@ -119,6 +119,7 @@ class Main(Screen[None]):
 
         PEPsView {
             width: 8fr;
+            scrollbar-gutter: stable;
         }
 
         PEPDetails {


### PR DESCRIPTION
This looks like a possible bug in Textual, but currently some of the separator lines are missing depending on the width of the terminal.

Setting `scrollbar-gutter: stable` seems to fix this issue.