### PR TITLE
Allow some more common list-navigation keys in option lists

### DIFF
--- a/src/peplum/app/widgets/extended_option_list.py
+++ b/src/peplum/app/widgets/extended_option_list.py
@@ -84,6 +84,9 @@ class OptionListEx(OptionList):
     BINDINGS = [
         Binding("j, right", "cursor_down", show=False),
         Binding("k, left", "cursor_up", show=False),
+        Binding("<", "first", show=False),
+        Binding(">", "last", show=False),
+        Binding("space", "page_down", show=False),
     ]
 
     @property


### PR DESCRIPTION
For those who are used to viewing things with the likes of `less`, for example. While not an ideal recreation, these are enough to cope with my muscle memory.