### PR TITLE
Drop Python 3.8

### DIFF
--- a/.github/workflows/style-lint-and-test.yaml
+++ b/.github/workflows/style-lint-and-test.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,8 @@
 - Made some cosmetic changes to the notes editor dialog so that it better
   matches the rest of the application.
   ([#18](https://github.com/davep/peplum/pull/18))
+- Dropped Python 3.8 as a supported Python version.
+  ([#19](https://github.com/davep/peplum/pull/19))
 
 ## v0.2.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "humanize>=4.11.0",
 ]
 readme = "README.md"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license = { text = "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)" }
 keywords = [
     "terminal",
@@ -34,7 +34,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
It's EOL now so there's little point in supporting it any more.