### PR TITLE
Remove OptionList scrollbar CSS from the app

### DIFF
--- a/src/peplum/app/peplum.py
+++ b/src/peplum/app/peplum.py
@@ -25,12 +25,6 @@ class Peplum(App[None]):
         SearchIcon {
             display: none;
         }
-        OptionList {
-            /* Make the scrollbar less gross. */
-            scrollbar-background: $panel;
-            scrollbar-background-hover: $panel;
-            scrollbar-background-active: $panel;
-        }
     }
 
     /* Make the LoadingIndicator look less like it was just slapped on. */


### PR DESCRIPTION
This is a hangover from borrowing from Braindrop, and I might need to remove it there too.