### PR TITLE
Add the `authors` property back

### DIFF
--- a/src/peplum/app/data/pep.py
+++ b/src/peplum/app/data/pep.py
@@ -146,7 +146,7 @@ class PEP:
     """The number of the PEP."""
     title: str
     """The title of the PEP."""
-    #    authors: str
+    authors: str
     """The authors of the PEP."""
     author_names: tuple[str, ...]
     """The names of the authors of the PEP."""
@@ -239,7 +239,7 @@ class PEP:
         return dict(
             number=data.get("number", -1),
             title=data.get("title", ""),
-            #            authors=data.get("authors"),
+            authors=data.get("authors"),
             author_names=tuple(data.get("author_names", [])),
             sponsor=data.get("sponsor"),
             delegate=data.get("delegate"),


### PR DESCRIPTION
Following on from #30: I'd commented this out for a moment so I could easily find all the code that referenced this field and swap it over to `author_names`, and then I forgot to put it back before merging #30.