### PR TITLE
Pin Textual to <2.0.0 for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = [
     "httpx>=0.28.1",
-    "textual>=1.0.0",
+    "textual>=1.0.0,<2",
     "xdg-base-dirs>=6.0.2",
     "typing-extensions>=4.12.2",
     "packaging>=24.2",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -10,9 +10,9 @@
 #   universal: false
 
 -e file:.
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.11
+aiohttp==3.11.12
     # via aiohttp-jinja2
     # via textual-dev
     # via textual-serve
@@ -44,9 +44,9 @@ httpcore==1.0.7
     # via httpx
 httpx==0.28.1
     # via peplum
-humanize==4.11.0
+humanize==4.12.0
     # via peplum
-identify==2.6.6
+identify==2.6.7
     # via pre-commit
 idna==3.10
     # via anyio
@@ -74,7 +74,7 @@ msgpack==1.1.0
 multidict==6.1.0
     # via aiohttp
     # via yarl
-mypy==1.14.1
+mypy==1.15.0
 mypy-extensions==1.0.0
     # via mypy
 nodeenv==1.9.1
@@ -101,14 +101,14 @@ rich==13.9.4
     # via textual-serve
 sniffio==1.3.1
     # via anyio
-textual==1.0.0
+textual==2.0.1
     # via peplum
     # via textual-dev
     # via textual-enhanced
     # via textual-fspicker
     # via textual-serve
 textual-dev==1.7.0
-textual-enhanced==0.4.0
+textual-enhanced==0.6.0
     # via peplum
 textual-fspicker==0.2.0
     # via peplum
@@ -121,7 +121,7 @@ typing-extensions==4.12.2
     # via textual-dev
 uc-micro-py==1.0.3
     # via linkify-it-py
-virtualenv==20.29.1
+virtualenv==20.29.2
     # via pre-commit
 xdg-base-dirs==6.0.2
     # via peplum

--- a/requirements.lock
+++ b/requirements.lock
@@ -21,7 +21,7 @@ httpcore==1.0.7
     # via httpx
 httpx==0.28.1
     # via peplum
-humanize==4.11.0
+humanize==4.12.0
     # via peplum
 idna==3.10
     # via anyio
@@ -46,11 +46,11 @@ rich==13.9.4
     # via textual
 sniffio==1.3.1
     # via anyio
-textual==1.0.0
+textual==2.0.1
     # via peplum
     # via textual-enhanced
     # via textual-fspicker
-textual-enhanced==0.4.0
+textual-enhanced==0.6.0
     # via peplum
 textual-fspicker==0.2.0
     # via peplum


### PR DESCRIPTION
Unsurprisingly the "rewritten" OptionList broke previously-valid code, so until I can dive into what's wrong, let's pin to Textual 1.x.