### PR TITLE
Make development environment current before making screens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,11 @@ console:			# Run the textual console
 
 ##############################################################################
 # Setup/update packages the system requires.
-.PHONY: setup
-setup:				# Set up the repository for development
+ready:				# Make the development environment ready to go
 	rye sync
+
+.PHONY: setup
+setup: ready			# Set up the repository for development
 	$(run) pre-commit install
 
 .PHONY: update
@@ -76,15 +78,15 @@ checkall: spellcheck codestyle lint stricttypecheck test # Check all the things
 ##############################################################################
 # Documentation.
 .PHONY: docs
-docs:                           # Generate the system documentation
+docs: ready			# Generate the system documentation
 	$(mkdocs) build
 
 .PHONY: rtfm
-rtfm:				# Locally read the library documentation
+rtfm: ready			# Locally read the library documentation
 	$(mkdocs) serve
 
 .PHONY: publishdocs
-publishdocs: clean-docs	# Set up the docs for publishing
+publishdocs: clean-docs ready	# Set up the docs for publishing
 	$(mkdocs) gh-deploy
 
 ##############################################################################

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ console:			# Run the textual console
 
 ##############################################################################
 # Setup/update packages the system requires.
+.PHONY: ready
 ready:				# Make the development environment ready to go
 	rye sync
 


### PR DESCRIPTION
Ensures that the current development environment is always the "installed" environment before making the screenshots for the docs; this means that the version number will always look correct.