### PR TITLE
Update the minimum-required version of Textual.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Peplum ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Made Textual v3.1.1 the minimum required version.
+  (#62[](https://github.com/davep/peplum/pull/62))
+
 ## v0.6.1
 
 **Released: 2025-04-12**

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -37,7 +37,7 @@
 
 **Released: 2025-03-17**
 
-- Bumped minimum Python version to 3.10.
+- Bumped minimum Python version to 3.1.0.
   ([#40](https://github.com/davep/peplum/pull/40))
 - Ensured the code works with *all* stable Python versions from 3.10 and
   above. ([#40](https://github.com/davep/peplum/pull/40))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,13 @@ authors = [
 ]
 dependencies = [
     "httpx>=0.28.1",
-    "textual>=3.1.0",
+    "textual>=3.1.1",
     "xdg-base-dirs>=6.0.2",
     "typing-extensions>=4.12.2",
     "packaging>=24.2",
     "humanize>=4.11.0",
     "textual-fspicker>=0.4.0",
-    "textual-enhanced>=0.4.0",
+    "textual-enhanced>=0.13.0",
 ]
 readme = "README.md"
 requires-python = ">= 3.10"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -12,7 +12,7 @@
 -e file:.
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.16
+aiohttp==3.11.18
     # via aiohttp-jinja2
     # via textual-dev
     # via textual-serve
@@ -28,7 +28,7 @@ babel==2.17.0
     # via mkdocs-material
 backrefs==5.8
     # via mkdocs-material
-certifi==2025.1.31
+certifi==2025.4.26
     # via httpcore
     # via httpx
     # via requests
@@ -46,20 +46,20 @@ distlib==0.3.9
     # via virtualenv
 filelock==3.18.0
     # via virtualenv
-frozenlist==1.5.0
+frozenlist==1.6.0
     # via aiohttp
     # via aiosignal
 ghp-import==2.1.0
     # via mkdocs
-h11==0.14.0
+h11==0.16.0
     # via httpcore
-httpcore==1.0.8
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via peplum
-humanize==4.12.2
+humanize==4.12.3
     # via peplum
-identify==2.6.9
+identify==2.6.10
     # via pre-commit
 idna==3.10
     # via anyio
@@ -98,7 +98,7 @@ mkdocs==1.6.1
     # via mkdocs-material
 mkdocs-get-deps==0.2.0
     # via mkdocs
-mkdocs-material==9.6.11
+mkdocs-material==9.6.12
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
 msgpack==1.1.0
@@ -107,11 +107,11 @@ multidict==6.4.3
     # via aiohttp
     # via yarl
 mypy==1.15.0
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.2
+packaging==25.0
     # via mkdocs
     # via peplum
     # via pytest
@@ -132,7 +132,7 @@ propcache==0.3.1
 pygments==2.19.1
     # via mkdocs-material
     # via rich
-pymdown-extensions==10.14.3
+pymdown-extensions==10.15
     # via markdown-exec
     # via mkdocs-material
 pytest==8.3.5
@@ -155,18 +155,18 @@ six==1.17.0
     # via python-dateutil
 sniffio==1.3.1
     # via anyio
-textual==3.1.0
+textual==3.1.1
     # via peplum
     # via textual-dev
     # via textual-enhanced
     # via textual-fspicker
     # via textual-serve
 textual-dev==1.7.0
-textual-enhanced==0.11.0
+textual-enhanced==0.13.0
     # via peplum
 textual-fspicker==0.4.1
     # via peplum
-textual-serve==1.1.1
+textual-serve==1.1.2
     # via textual-dev
 typing-extensions==4.13.2
     # via mypy
@@ -183,5 +183,5 @@ watchdog==6.0.0
     # via mkdocs
 xdg-base-dirs==6.0.2
     # via peplum
-yarl==1.19.0
+yarl==1.20.0
     # via aiohttp

--- a/requirements.lock
+++ b/requirements.lock
@@ -12,16 +12,16 @@
 -e file:.
 anyio==4.9.0
     # via httpx
-certifi==2025.1.31
+certifi==2025.4.26
     # via httpcore
     # via httpx
-h11==0.14.0
+h11==0.16.0
     # via httpcore
-httpcore==1.0.8
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via peplum
-humanize==4.12.2
+humanize==4.12.3
     # via peplum
 idna==3.10
     # via anyio
@@ -36,7 +36,7 @@ mdit-py-plugins==0.4.2
     # via markdown-it-py
 mdurl==0.1.2
     # via markdown-it-py
-packaging==24.2
+packaging==25.0
     # via peplum
 platformdirs==4.3.7
     # via textual
@@ -46,11 +46,11 @@ rich==14.0.0
     # via textual
 sniffio==1.3.1
     # via anyio
-textual==3.1.0
+textual==3.1.1
     # via peplum
     # via textual-enhanced
     # via textual-fspicker
-textual-enhanced==0.11.0
+textual-enhanced==0.13.0
     # via peplum
 textual-fspicker==0.4.1
     # via peplum


### PR DESCRIPTION
Also bump the minimum-required `textual-enhanced` too.

Closes #57. (actually I think #60 might have done that; but let's credit it here to keep some sense of when things happened in time).