### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/style-lint-and-test.yaml
+++ b/.github/workflows/style-lint-and-test.yaml
@@ -11,6 +11,8 @@ jobs:
   style-lint-and-test:
 
     name: Style, lint, test
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/davep/peplum/security/code-scanning/1](https://github.com/davep/peplum/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block in the workflow or job so that the `GITHUB_TOKEN` has only the minimum access required. For this job, it only checks out code and runs local tooling, so `contents: read` is sufficient; it does not need to write to the repo, update PRs, or interact with other resources.

The minimal, non‑functional‑changing fix is to add a `permissions` block to the `style-lint-and-test` job definition. Place it under the job name (and before `runs-on`) so it only applies to this job. The block should be:

```yaml
permissions:
  contents: read
```

No imports or external dependencies are required; this is a pure YAML configuration change in `.github/workflows/style-lint-and-test.yaml`. No other parts of the workflow need modification, since the existing steps only require read access to the repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
